### PR TITLE
Add a autoresponse to !canrepo so people can fix their mistake.

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,12 @@ bot.on('messageCreate', (msg) => {
         }
       }
 
+      if(command.toLowerCase() === "!canrepo") {
+        bot.createMessage(channelID, "<@" + userID + ">, This is not a command, perhaps you were trying for '!canrepro'?").then(delay(config.delayInMS)).then((innerMsg) => {
+          bot.deleteMessage(innerMsg.channel.id, innerMsg.id);
+          bot.deleteMessage(channelID, msg.id);
+      }
+
       if(command.toLowerCase() === "!cannotrepro" || command.toLowerCase() === "!cantrepro"){
         var joinedMessage = messageSplit.join(' ');
         var trelloURL = joinedMessage.replace(/(?:(<)?(?:https?:\/\/)?(?:www\.)?trello.com\/c\/)?([^\/|\s|\>]+)(\/|\>)?(?:[\w-\d]*)?(\/|\>|\/>)?\s*\|\s*([\s\S]*)/gi, "$2");


### PR DESCRIPTION
Since forgeting the 'r' in '!canrepro' is a freqent issue, give an repsone so people know to fix their message.