### PR TITLE
Adding toProperCase

### DIFF
--- a/commands/storeInfo.js
+++ b/commands/storeInfo.js
@@ -77,13 +77,13 @@ let storeSysInfo = {
       if(!!dbRowReply){
         //Edit existing database entry
         db.run("UPDATE users SET " + whichOS + " = ? WHERE userid = ?", [systemInfo, userID]);
-        utils.botReply(bot, userID, channelID, "your new " + utils.toTitleCase(whichOS) + " settings have been saved", command, msg.id);
-        bot.createMessage(config.channels.modLogChannel, ":floppy_disk: **" + userTag + "** changed **" + utils.toTitleCase(whichOS) + "** -> `" + systemInfo + "`"); //user changed their --- info
+        utils.botReply(bot, userID, channelID, "your new " + utils.toProperCase(whichOS) + " settings have been saved", command, msg.id);
+        bot.createMessage(config.channels.modLogChannel, ":floppy_disk: **" + userTag + "** changed **" + utils.toProperCase(whichOS) + "** -> `" + systemInfo + "`"); //user changed their --- info
       }else if(!dbRowReply){
         //Create new database entry
         db.run("INSERT INTO users (userid, " + whichOS + ") VALUES(?, ?)", [userID, systemInfo]);
-        utils.botReply(bot, userID, channelID, "your new " + utils.toTitleCase(whichOS) + " settings have been saved", command, msg.id);
-        bot.createMessage(config.channels.modLogChannel, ":floppy_disk: **" + userTag + "** added **" + utils.toTitleCase(whichOS) + "** -> `" + systemInfo + "`"); //user added their --- info
+        utils.botReply(bot, userID, channelID, "your new " + utils.toProperCase(whichOS) + " settings have been saved", command, msg.id);
+        bot.createMessage(config.channels.modLogChannel, ":floppy_disk: **" + userTag + "** added **" + utils.toProperCase(whichOS) + "** -> `" + systemInfo + "`"); //user added their --- info
       }
     });
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,5 +47,6 @@ function toProperCase(editString){
 module.exports = {
   delay: delay,
   botReply: botReply,
-  toTitleCase: toTitleCase
+  toTitleCase: toTitleCase,
+  toProperCase: toProperCase
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,6 +40,10 @@ function toTitleCase(editString) {
     return editString.replace(/\w\S*/g, function(text) { return text.charAt(0).toUpperCase() + text.substr(1).toLowerCase();});
 }
 
+function toProperCase(editString){
+    return editString.replace(/\w\S*/g, function(text) { return text.charAt(0).toUpperCase() + text.slice(1);});
+}
+
 module.exports = {
   delay: delay,
   botReply: botReply,


### PR DESCRIPTION
Changing the usage of toTitleCase to toProperCase, so we can get MacOS, rather than Macos as the storeinfo for Macs.