### PR TITLE
Better RegEx for the system flags

### DIFF
--- a/commands/adminCommands.js
+++ b/commands/adminCommands.js
@@ -20,7 +20,7 @@ let adminCommands = {
           return;
         }
         let key = contentMessage[1];
-        let whichClient = contentMessage[2].match(/(?:\s)(-l|-m|-w|-a|-i)/i);
+        let whichClient = contentMessage[2].match(/(?:\B)(-l|-m|-w|-a|-i)(?:\b)/i);
         let ADContent;
         //Check if ADcontent exists or not, reply "missing reason/user settings" if it's missing
         if(!contentMessage[2]) {

--- a/commands/approveDeny.js
+++ b/commands/approveDeny.js
@@ -50,7 +50,7 @@ let approveDeny = {
         return;
       }
       contentMessage[2] = contentMessage[2].replace(/(\*|`|\~|\_|\ˋ)/gi, "\\$&");
-      let whichClient = contentMessage[2].match(/(?:\s)(-l|-m|-w|-a|-i)/i);
+      let whichClient = contentMessage[2].match(/(?:\B)(-l|-m|-w|-a|-i)(?:\b)/i);
       let ADcontent;
       //Check if ADcontent exists or not, reply "missing reason/user settings" if it's missing
       if(!contentMessage[2]) {
@@ -73,7 +73,7 @@ let approveDeny = {
         db.get("SELECT " + system + " FROM users WHERE userid = ?", [userID], function(error, usrSys) {
           if(!!usrSys){
             let info = contentMessage[2];
-            ADcontent = info.replace(/(?:\s)(-l|-m|-w|-a|-i)/i, " " + usrSys[system]);
+            ADcontent = info.replace(/(?:\B)(-l|-m|-w|-a|-i)(?:\b)/i, usrSys[system]);
             addApproval (bot, channelID, userTag, userID, command, msg, db, key, ADcontent, reportInfo, trello);
           } else {
             utils.botReply(bot, userID, channelID, "doesn't seem like you have that client in our database. You can add it with `!storeinfo " + whichClient[1] + " | system info`", command, msg.id, false);


### PR DESCRIPTION
Currently, the `/(?:\s)(-l|-m|-w|-a|-i)/i` pattern doesn't allow the use of this anymore: `!approve 1100 | -a` or `!approve 1100 | -w, Canary`. This new pattern fixes that, whilst it should also still ignore links.